### PR TITLE
Use 4M OVMF images instead of the 2M ones by default.

### DIFF
--- a/scripts/install_vm.sh
+++ b/scripts/install_vm.sh
@@ -14,7 +14,7 @@ OVMF_VARS_TEMPLATE=${OVMF_VARS_TEMPLATE:-"/usr/share/edk2/ovmf/OVMF_VARS.fd"}
 set -xe 
 
 force=false
-while getopts "k:b:n:f p:s" opt; do
+while getopts "k:b:n:f p:s:" opt; do
   case $opt in
 	k) key=$OPTARG ;;
 	b) butane=$OPTARG ;;

--- a/scripts/install_vm.sh
+++ b/scripts/install_vm.sh
@@ -20,8 +20,8 @@ while getopts "k:b:n:f p:s" opt; do
 	b) butane=$OPTARG ;;
 	f) force=true ;;
 	n) VM_NAME=$OPTARG ;;
-    p) PORT=$OPTARG ;;
-    s) STREAM=$OPTARG ;;
+	p) PORT=$OPTARG ;;
+	s) STREAM=$OPTARG ;;
 	\?) echo "Invalid option"; exit 1 ;;
   esac
 done

--- a/scripts/install_vm.sh
+++ b/scripts/install_vm.sh
@@ -8,8 +8,8 @@ VCPUS="2"
 RAM_MB="2048"
 DISK_GB="10"
 PORT="2222"
-OVMF_CODE=${OVMF_CODE:-"/usr/share/edk2/ovmf/OVMF_CODE.fd"}
-OVMF_VARS_TEMPLATE=${OVMF_VARS_TEMPLATE:-"/usr/share/edk2/ovmf/OVMF_VARS.fd"}
+OVMF_CODE=${OVMF_CODE:-"/usr/share/edk2/ovmf/OVMF_CODE_4M.secboot.qcow2"}
+OVMF_VARS_TEMPLATE=${OVMF_VARS_TEMPLATE:-"/usr/share/edk2/ovmf/OVMF_VARS_4M.secboot.qcow2"}
 
 set -xe 
 

--- a/scripts/install_vm.sh
+++ b/scripts/install_vm.sh
@@ -11,7 +11,7 @@ PORT="2222"
 OVMF_CODE=${OVMF_CODE:-"/usr/share/edk2/ovmf/OVMF_CODE_4M.secboot.qcow2"}
 OVMF_VARS_TEMPLATE=${OVMF_VARS_TEMPLATE:-"/usr/share/edk2/ovmf/OVMF_VARS_4M.secboot.qcow2"}
 
-set -xe 
+set -xe
 
 force=false
 while getopts "k:b:n:f p:s:" opt; do


### PR DESCRIPTION
The 2M images would lead to empty pcrs and some messages about TPM errors. This is due to the latest fedora OVMF build not supporting TPMs in the 2M images. The main reason behind it is image size and not being able to fit all features there.

4M images support it instead, so we should use them by default.

I'm also adding a couple of style fixes and fixing the stream selection arg in install_vm.sh.

cc: @alicefr 