### PR TITLE
Example of attestation and disk encryption

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,3 +11,33 @@ scripts/install_vm.sh  -b config.bu -k "$(cat coreos.key.pub)"
 ```bash
 scripts/uninstall_vm.sh  -n <vm_name>"
 ```
+
+## Example with local VMs, attestation and disk encryption
+
+Currently, ignition does not support encrypting the disk using trustee (see this 
+[RFC](https://github.com/coreos/ignition/issues/2099) for more details). Therefore, we need to build a custom initramfs
+which contains the trustee attester, and the KBS information hardcoded in the setup script.
+
+Build the Fedora Coreos image with the custom initrd:
+```bash
+scripts/build-fcos-image.sh
+```
+
+In this example, we use 2 VMs, the first for running the trustee server while the second VM has been attested and its
+root disk is encrypted using the secret stored in Trustee.
+
+As already mentioned, the information are hardcoded in the initial script since we lack ignition support. Hence, if the
+entire setup feels rigid and manual, it will improve in the future with the ignition extension.
+
+Both VMs are created from the same image in order to retrieve the PCR registers from the TPM. This step and the VM can
+be avoided once we are able to pre-calculate the PCRs.
+
+The script `create_vms.sh`:
+  1. launches the first VM with Trustee
+  2. waits until Trustee is reachable at port `8080`
+  3. populates the KBS with the reference values, the attestation policy for register 4, 7, and 14, and the secret
+  4. creates the second VM which will perform the attestation in order to encrypt its root disk
+
+```bash
+scripts/create-vms.sh coreos.key.pub 
+```

--- a/encrypt-disk/config.bu
+++ b/encrypt-disk/config.bu
@@ -1,0 +1,44 @@
+variant: fcos
+version: 1.6.0
+passwd:
+  users:
+    - name: core
+      ssh_authorized_keys:
+      - <KEY>
+
+systemd:
+  units:
+    - name: serial-getty@ttyS0.service
+      dropins:
+      - name: autologin-core.conf
+        contents: |
+          [Service]
+          # Override Execstart in main unit
+          ExecStart=
+          # Add new Execstart with `-` prefix to ignore failure`
+          ExecStart=-/usr/sbin/agetty --autologin core --noclear %I $TERM
+
+storage:
+  luks:
+    - name: root
+      label: luks-root
+      device: /dev/disk/by-partlabel/root
+      clevis:
+        custom:
+          needs_network: false
+          pin: tpm2
+          config: '{"pcr_bank":"sha256","pcr_ids":"7"}'
+      wipe_volume: true
+  filesystems:
+    - device: /dev/mapper/root
+      format: xfs
+      wipe_filesystem: true
+      label: root
+
+  files:
+    - path: /etc/profile.d/systemd-pager.sh
+      mode: 0644
+      contents:
+        inline: |
+          # Tell systemd to not use a pager when printing information
+          export SYSTEMD_PAGER=cat

--- a/encrypt-disk/files/Containerfile
+++ b/encrypt-disk/files/Containerfile
@@ -1,0 +1,24 @@
+FROM quay.io/afrosi_rh/kbs-client-image:latest as kbc
+FROM quay.io/fedora/fedora-coreos:stable
+
+USER root
+COPY initrd-trustee_plus/dracut/dracut.conf /etc/dracut.conf
+COPY initrd-trustee_plus/dracut/65aaclient /usr/lib/dracut/modules.d/65aaclient
+COPY initrd-trustee_plus/scripts/aa-client-service.sh /usr/bin/aa-client-service.sh
+COPY initrd-trustee_plus/systemd/aa-client.service /usr/lib/systemd/system/aa-client.service
+COPY --from=kbc /usr/local/bin/kbs-client /usr/bin/trustee-attester
+
+RUN chmod +x /usr/bin/aa-client-service.sh
+RUN set -xeuo pipefail && \
+    KERNEL_VERSION="$(basename $(ls -d /lib/modules/*))" && \
+    raw_args="$(	lsinitrd /lib/modules/${KERNEL_VERSION}/initramfs.img | grep '^Arguments: ' | sed 's/^Arguments: //')" && \
+    stock_arguments=$(echo "$raw_args" | sed "s/'//g") && \
+    echo "Using kernel: $KERNEL_VERSION" && \
+    echo "Arguments: $stock_arguments" && \
+    mkdir -p /tmp/dracut /var/roothome && \
+    dracut $stock_arguments && \
+    mv -v "/lib/modules/${KERNEL_VERSION}/initramfs.img" "/lib/modules/${KERNEL_VERSION}/initramfs.stock.img" && \
+    mv -v /boot/initramfs*.img "/lib/modules/${KERNEL_VERSION}/initramfs.img" && \
+    ostree container commit
+
+RUN lsinitrd /lib/modules/*/initramfs.img | grep "aa-client"

--- a/encrypt-disk/files/initrd-trustee_plus/dracut/65aaclient/module-setup.sh
+++ b/encrypt-disk/files/initrd-trustee_plus/dracut/65aaclient/module-setup.sh
@@ -1,0 +1,37 @@
+#!/bin/bash
+
+check() {
+    echo "UUU in aa-client-module-setup check($@) CHECK"
+    # return 255
+}
+
+depends() {
+    echo crypt systemd network
+}
+
+install () {
+    echo "UUU in aa-client-module-setup install($@) INSTALL 3333"
+    inst $systemdsystemunitdir/aa-client.service
+    inst /usr/bin/aa-client-service.sh
+    inst /usr/bin/trustee-attester
+    
+    inst curl
+    inst strace
+    inst cryptsetup
+    inst tr
+    inst lsblk
+    inst mktemp
+    inst base64
+    inst /usr/lib/systemd/systemd-reply-password
+
+    systemctl -q --root "$initdir" add-wants initrd.target        aa-client.service
+
+    # need to figure out why systemd-unit-file get x mode
+    chmod -x $systemdsystemunitdir/aa-client.service
+
+    # need network -- figure out how to do it without chaning the command line
+    echo "rd.neednet=1" >  "${initdir}/etc/cmdline.d/65aa-client.conf"
+
+
+    echo "UUU in aa-client-module-setup install($@) INSTALL DONE"
+}

--- a/encrypt-disk/files/initrd-trustee_plus/dracut/dracut.conf
+++ b/encrypt-disk/files/initrd-trustee_plus/dracut/dracut.conf
@@ -1,0 +1,4 @@
+# PUT YOUR CONFIG IN separate files
+# in /etc/dracut.conf.d named "<name>.conf"
+# SEE man dracut.conf(5) for options
+force_drivers+=" sev-guest "

--- a/encrypt-disk/files/initrd-trustee_plus/scripts/aa-client-service.sh
+++ b/encrypt-disk/files/initrd-trustee_plus/scripts/aa-client-service.sh
@@ -1,0 +1,156 @@
+#!/bin/bash
+. /lib/dracut-lib.sh
+set -x
+
+# Configuration
+KBS_IP=$(ip route | awk '/^default/ {print $3}')
+KBS_PORT="8080"
+KBS_URL="http://${KBS_IP}:${KBS_PORT}"
+ROOT_DEVICE=$(blkid -L root)
+CRYPT_ROOT_NAME="luks-root"
+BOOT_DEVICE="/dev/disk/by-label/boot"
+BOOT_MOUNT="/mnt/boot_partition"
+MARKER_FILE="${BOOT_MOUNT}/.trustee_done"
+CRYPTTAB_FILE="/sysroot/etc/crypttab"
+MAX_RETRY_ATTEMPTS=3
+RETRY_DELAY=5
+
+# temp configuration
+TEMP_DIR=$(mktemp -d /tmp/secure_attestation_XXXXXX)
+PASSPHRASE_FILE="${TEMP_DIR}/passphrase"
+OLD_PASS_FILE="${TEMP_DIR}/old_passphrase"
+
+# Make sure the safety of temp files
+umask 077
+# Clean function - make sure it is always executed
+cleanup() {
+    # Securely clean the sensitive data from memory
+    if [ -n "${passphrase}" ]; then
+        passphrase="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+    fi
+    
+    # umount the mountpoint
+    umount "${BOOT_MOUNT}" 2>/dev/null || true
+    
+    # Delete the temp files or directories
+    rm -rf "${TEMP_DIR}"
+    
+    info "*** ATTESTATION SERVICE COMPLETED ***"
+}
+trap cleanup EXIT
+
+fetch_passphrase() {
+    local attempts=$MAX_RETRY_ATTEMPTS
+    local count=0
+    local result=""
+    local status=0
+
+    while [ $count -lt $attempts ] && [ -z "$result" ]; do
+        info "Attempt $((count+1)): Fetching passphrase from ${KBS_URL}"
+	
+        if ! result=$(/usr/bin/trustee-attester --url "${KBS_URL}" get-resource --path default/rootdecrypt/key1 2>/dev/null); then
+	    status=$?
+	    info "Attestation failed with status $status"
+            sleep $RETRY_DELAY
+	elif [ -n "$result" ]; then
+            info "Successfully retrieved passphrase"
+            break
+        else
+            info "Empty response received"
+            sleep $RETRY_DELAY
+        fi
+        
+        count=$((count+1))
+    done
+    
+    if [ -z "$result" ]; then
+        info "Failed to retrieve passphrase after $attempts attempts"
+        return 1
+    fi
+    
+    echo "$result"
+    return 0
+}
+
+replace_luks_key() {
+    local device=$1
+    local new_key=$2
+
+    info "Getting current LUKS key"
+    . clevis-luks-common-functions
+    local pt=$(clevis_luks_unlock_device "${device}")
+    echo -n "${pt}" > "${OLD_PASS_FILE}"
+    chmod 600 "${OLD_PASS_FILE}"
+    pt="xxxxxxxxxx"  # Erase the passphrase from memory
+
+    if ! /usr/sbin/cryptsetup --verbose open --test-passphrase "${device}" --key-file="${OLD_PASS_FILE}"; then
+        info "Failed to verify old key" 
+        return 1
+    fi
+
+    info "Replacing LUKS key"
+    /usr/sbin/cryptsetup luksAddKey "${device}" --key-file="${OLD_PASS_FILE}" "${new_key}" || return 1
+    /usr/sbin/cryptsetup luksKillSlot "${device}" 1 --key-file="${new_key}" || return 1
+
+    info "Do verification of new LUKS key"
+    if ! /usr/sbin/cryptsetup --verbose open --test-passphrase "${device}" --key-file="${new_key}"; then
+        info "Failed to verify new key"
+        return 1
+    fi
+
+    info "Removing LUKS token"
+    /usr/sbin/cryptsetup token remove "${device}" --token-id 0
+
+    info "Create marker file"
+    touch "${MARKER_FILE}"
+    info "LUKS key replacement completed successfully"
+}
+
+# Main execution
+info "*** ATTESTATION SERVICE FOR DISK ENCRYPTION ***"
+
+# Check if root is already decrypted
+if [ -e "/dev/mapper/${CRYPT_ROOT_NAME}" ]; then
+    info "Root device already decrypted"
+    exit 0
+fi
+
+# Fetch passphrase
+passphrase_base64=$(fetch_passphrase)
+[ -z "$passphrase_base64" ] && { info "No passphrase received"; exit 1; }
+
+passphrase=$(echo "$passphrase_base64" | base64 -d | tr -cd '[:print:]')
+echo -n "$passphrase" > "${PASSPHRASE_FILE}"
+chmod 600 "${PASSPHRASE_FILE}"
+
+# Mount boot partition
+mkdir -p "${BOOT_MOUNT}"
+if ! mount -o rw "${BOOT_DEVICE}" "${BOOT_MOUNT}" 2>/dev/null; then
+    info "Warning: Could not mount boot partition - assuming first boot"
+    BOOT_MOUNTED=false
+else
+    BOOT_MOUNTED=true
+fi
+
+if $BOOT_MOUNTED && [ -f "${MARKER_FILE}" ]; then
+    info "Normal boot: Decrypting root filesystem"
+    info "ATTESTATION SERVICE: Decrypting root filesystem with fetched key"
+    if /usr/sbin/cryptsetup --verbose open ${ROOT_DEVICE} ${CRYPT_ROOT_NAME} --key-file=${PASSPHRASE_FILE}; then
+        info "ATTESTATION SERVICE: Successfully decrypted root filesystem"
+    else
+        info "ATTESTATION SERVICE: Failed to decrypt root filesystem"
+    	exit 1
+    fi
+else
+    info "First boot: Replacing LUKS key"
+    replace_luks_key "${ROOT_DEVICE}" "${PASSPHRASE_FILE}" || exit 1
+
+    # Prevent the system from calling systemd-cryptsetup@root.service 
+    # to decrypt LUKS devices during other-boots.
+    if [ -f "${CRYPTTAB_FILE}" ]; then
+        info "Clearing crypttab file"
+        echo > "${CRYPTTAB_FILE}" || info "Warning: Could not clear crypttab file"
+    else
+        info "Warning: Crypttab file not found at ${CRYPTTAB_FILE}"
+    fi
+fi

--- a/encrypt-disk/files/initrd-trustee_plus/systemd/aa-client.service
+++ b/encrypt-disk/files/initrd-trustee_plus/systemd/aa-client.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Confidential Containers Attestaion Agent Simple Client
+Before=cryptsetup.target
+Before=initrd-switch-root.target
+Before=ignition-complete.target
+Before=systemd-cryptsetup@root.service
+After=network-online.target
+After=dev-disk-by\x2dlabel-boot.device
+After=ignition-files.service
+Wants=network-online.target
+Requires=dev-disk-by\x2dlabel-boot.device
+
+[Service]
+SyslogLevel=debug
+Type=oneshot
+ExecStart=/usr/bin/aa-client-service.sh
+MountFlags=slave

--- a/scripts/build-fcos-image.sh
+++ b/scripts/build-fcos-image.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+IMG=fcos-cvm
+ociarchive=${IMG}.tar
+
+set -xe
+
+TMPDIR=$(mktemp -d)
+git clone --depth 1 https://github.com/coreos/custom-coreos-disk-images ${TMPDIR}
+
+sudo podman build -t ${IMG} -f encrypt-disk/files/Containerfile  encrypt-disk/files
+sudo skopeo copy containers-storage:localhost/fcos-cvm:latest oci-archive:${ociarchive}
+sudo -E ${TMPDIR}/custom-coreos-disk-images.sh --platform qemu \
+	--ociarchive fcos-cvm.tar \
+	--osname fedora-coreos
+rm -rf "$TMPDIR"
+sudo chown qemu:qemu ${ociarchive}-qemu.x86_64.qcow2

--- a/scripts/create-vms.sh
+++ b/scripts/create-vms.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+KEY=$1
+TRUSTEE_SSH_PORT=2222
+VM_SSH_PORT=2223
+IMAGE=$(pwd)/fcos-cvm.tar-qemu.x86_64.qcow2
+TRUSTEE_PORT=8080
+
+if [ -z "$KEY" ]; then
+	echo "Please provide the public key"
+	exit 1
+fi
+
+scripts/install_vm.sh  -n trustee  -b trustee/config.bu -k "$(cat $KEY)" -f  -p ${TRUSTEE_SSH_PORT} \
+	-i ${IMAGE} -d trustee -t ${TRUSTEE_PORT}
+
+until curl http://127.0.0.2:${TRUSTEE_PORT}; do
+  echo "Waiting for KBS to be available..."
+  sleep 1
+done
+until ssh core@localhost -p ${TRUSTEE_SSH_PORT} -i coreos.key \
+  -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null \
+  'sudo /usr/local/bin/populate_kbs.sh'; do
+	echo "Waiting for KBS to be populate"
+	sleep 1
+done
+
+scripts/install_vm.sh  -n vm  -b encrypt-disk/config.bu -k "$(cat $KEY)" -f  -p ${VM_SSH_PORT} \
+	-i ${IMAGE}

--- a/trustee/config.bu
+++ b/trustee/config.bu
@@ -33,6 +33,10 @@ storage:
         inline: |
           # Tell systemd to not use a pager when printing information
           export SYSTEMD_PAGER=cat
+    - path: /usr/local/bin/populate_kbs.sh
+      mode: 0755
+      contents:
+        local: files/populate_kbs.sh
     - path: /etc/containers/systemd/key-generation.container
       mode: 0644
       contents:

--- a/trustee/files/containers/as-grpc.container
+++ b/trustee/files/containers/as-grpc.container
@@ -7,7 +7,7 @@ Requires=rvps.container
 
 [Container]
 ContainerName=as
-Image=ghcr.io/confidential-containers/staged-images/coco-as-grpc:latest
+Image=quay.io/afrosi_rh/coco-as-grpc:latest
 Network=trustee.network
 Entrypoint=/usr/local/bin/grpc-as
 PublishPort=50004:50004

--- a/trustee/files/containers/kbc.container
+++ b/trustee/files/containers/kbc.container
@@ -4,7 +4,7 @@ After=key-generation.container
 
 [Container]
 ContainerName=kbs-client
-Image=ghcr.io/confidential-containers/staged-images/kbs-client-image
+Image=quay.io/afrosi_rh/kbs-client-image:latest
 Network=trustee.network
 Volume=user-keys:/opt/confidential-containers/kbs/user-keys
 Exec=tail -f /dev/null

--- a/trustee/files/containers/kbs.container
+++ b/trustee/files/containers/kbs.container
@@ -4,10 +4,11 @@ After=key-generation.container
 
 [Container]
 ContainerName=kbs
-Image=ghcr.io/confidential-containers/staged-images/kbs-grpc-as:latest
+Image=quay.io/afrosi_rh/kbs-grpc-as:latest
 Network=trustee.network
 Entrypoint=/usr/local/bin/kbs
 PublishPort=8080:8080
+Environment=RUST_LOG=debug
 Volume=/var/kbs/config/kbs-config.toml:/opt/confidential-containers/kbs/config/kbs-config.toml:z
 Volume=kbs-storage:/opt/confidential-containers/kbs/repository
 Volume=nebula-ca:/opt/confidential-containers/kbs/nebula-ca

--- a/trustee/files/populate_kbs.sh
+++ b/trustee/files/populate_kbs.sh
@@ -1,0 +1,79 @@
+#!/bin/bash
+
+set -xe
+
+KBS=kbs:8080
+SECRET_PATH=${SECRET_PATH:=default/rootdecrypt/key1}
+KEY=${KEY:=/opt/confidential-containers/kbs/user-keys/private.key}
+
+podman exec -ti kbs-client \
+	kbs-client --url http://${KBS}  config \
+		--auth-private-key ${KEY} \
+		set-sample-reference-value tpm_svn "1"
+for i in {4,7,14}; do
+    value=$(sudo tpm2_pcrread sha256:${i} | awk -F: '/0x/ {sub(/.*0x/, "", $2); gsub(/[^0-9A-Fa-f]/, "", $2); print tolower($2)}')
+	podman exec -ti kbs-client \
+		 kbs-client --url http://${KBS}  config \
+			--auth-private-key ${KEY} \
+			set-sample-reference-value tpm_pcr${i} "${value}"
+done
+
+# Check reference values
+podman exec -ti kbs-client \
+	kbs-client --url http://${KBS}  config \
+		--auth-private-key ${KEY} \
+		get-reference-values
+
+
+# Create attestation policy
+cat << 'EOF' > tpm.rego
+package policy
+import rego.v1
+default hardware := 97
+default configuration := 36
+
+##### TPM
+hardware := 2 if {
+	input.tpm.svn in data.reference.tpm_svn
+}
+
+tpm_pcrs_valid if {
+  input.tpm.pcrs[4] in data.reference.tpm_pcr4
+  input.tpm.pcrs[7] in data.reference.tpm_pcr7
+  input.tpm.pcrs[14] in data.reference.tpm_pcr14
+}
+
+executables := 3 if tpm_pcrs_valid
+configuration := 2 if tpm_pcrs_valid
+
+##### Final decision
+allow if {
+  hardware == 2
+  executables == 3
+  configuration == 2
+}
+EOF
+
+podman cp tpm.rego kbs-client:/tpm.rego
+podman exec -ti kbs-client \
+	kbs-client --url http://${KBS}  config \
+		--auth-private-key ${KEY} \
+		set-attestation-policy \
+		--policy-file tpm.rego \
+		--type rego --id default_cpu
+
+# Upload resource
+cat > test_data << EOF
+1234567890abcde
+EOF
+podman cp test_data kbs-client:/secret
+podman exec -ti kbs-client \
+	kbs-client --url http://${KBS}  config \
+		--auth-private-key ${KEY} \
+		set-resource --resource-file /secret \
+		--path ${SECRET_PATH}
+
+podman exec -ti kbs-client \
+	kbs-client --url http://${KBS}  config \
+		--auth-private-key ${KEY} \
+		set-resource-policy --affirming


### PR DESCRIPTION
This changes allows to run a full attestation and encryption of a root disk on a firstboot. More details are explained in the README.

This PR is based on the steps illustrated by https://github.com/confidential-clusters/investigations/pull/5 . However, the `aa-client-service.sh` has been modified in order to match the local environment of the example and the initrd is based on the upstream fedora coreos.

The example includes some images from my quay account. They includes the support for the TPM verifier and they are based on these ongoing PRs:
- https://github.com/confidential-containers/guest-components/pull/1050
- https://github.com/confidential-containers/trustee