### PR TITLE
Sync secret path with operator

### DIFF
--- a/configs/trustee/populate_kbs.sh
+++ b/configs/trustee/populate_kbs.sh
@@ -3,7 +3,7 @@
 set -xe
 
 KBS=kbs:8080
-SECRET_PATH=${SECRET_PATH:=default/rootdecrypt/key1}
+SECRET_PATH=${SECRET_PATH:=default/machine/root}
 KEY=${KEY:=/opt/confidential-containers/kbs/user-keys/private.key}
 
 podman exec -ti kbs-client \

--- a/fedora-coreos/usr/libexec/aa-client
+++ b/fedora-coreos/usr/libexec/aa-client
@@ -48,7 +48,7 @@ fetch_passphrase() {
     while [ $count -lt $attempts ] && [ -z "$result" ]; do
         info "Attempt $((count+1)): Fetching passphrase from ${KBS_URL}"
 
-        if ! result=$(/usr/bin/trustee-attester --url "${KBS_URL}" get-resource --path default/rootdecrypt/key1 2>/dev/null); then
+        if ! result=$(/usr/bin/trustee-attester --url "${KBS_URL}" get-resource --path default/machine/root 2>/dev/null); then
         status=$?
         info "Attestation failed with status $status"
             sleep $RETRY_DELAY


### PR DESCRIPTION
cocl-operator will feature a node ID in the secret path (https://github.com/confidential-clusters/cocl-operator/pull/10) and intermittently calls the single expected node (the VM from this repository) `machine`. Update the secret path.

Also update this in populate_kbs.sh to maintain compatibility with a double-VM setup.