### PR TITLE
Build and push Trustee containers

### DIFF
--- a/.github/workflows/build-trustee-image.yml
+++ b/.github/workflows/build-trustee-image.yml
@@ -1,11 +1,11 @@
-name: Build Trustee Container Image
+name: Build Trustee Container Images
 
 on:
   push:
     branches:
       - main
     paths:
-      - 'configs/trustee/containers/trustee.container'
+      - 'configs/trustee/containers/trustee**'
   workflow_dispatch: # Allows manual triggering of the workflow
 
 jobs:
@@ -14,6 +14,14 @@ jobs:
     container:              # All steps below will run inside this container
       image: fedora:latest  # Using the latest Fedora image
       options: --privileged # Required for Buildah to build images without rootless setup
+    strategy:
+      matrix:
+        include:
+          - image-name: 'trustee'
+            containerfile-path: 'configs/trustee/containers/trustee.container'
+          - image-name: 'trustee-attester'
+            containerfile-path: 'configs/trustee/containers/trustee-attester.container'
+
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -24,20 +32,20 @@ jobs:
           dnf install -y buildah git
           dnf clean all
 
-      - name: Set image name and tag
+      - name: Set image name for ${{ matrix.image-name }}
         run: |
           # Fix IMAGE_TAG if other branches are added at the top
           IMAGE_TAG="latest"
-          IMAGE_NAME="quay.io/confidential-clusters/trustee:${IMAGE_TAG}"
+          IMAGE_NAME="quay.io/confidential-clusters/${{ matrix.image-name }}:${IMAGE_TAG}"
           # "pass" IMAGE_NAME to the following steps
           echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
           echo "Image name is $IMAGE_NAME"
 
-      - name: Build container image
+      - name: Build container image ${{ matrix.image-name }}
         run: |
-          buildah build -t "${{ env.IMAGE_NAME }}" -f configs/trustee/containers/trustee.container .
+          buildah build -t "${{ env.IMAGE_NAME }}" -f ${{ matrix.containerfile-path }} .
 
-      - name: Push container image
+      - name: Push container image ${{ matrix.image-name }}
         run: |
           # skip this step if username or password are not defined
           if [ "X${{ secrets.REGISTRY_USERNAME }}" == "X" \

--- a/.github/workflows/build-trustee-image.yml
+++ b/.github/workflows/build-trustee-image.yml
@@ -48,8 +48,10 @@ jobs:
       - name: Push container image ${{ matrix.image-name }}
         run: |
           # skip this step if username or password are not defined
-          if [ "X${{ secrets.REGISTRY_USERNAME }}" == "X" \
-               "X${{ secrets.REGISTRY_PASSWORD }}" == "X" ];
+          # skip in forks too
+          if [ "X${{ secrets.REGISTRY_USERNAME }}" == "X" -o \
+               "X${{ secrets.REGISTRY_PASSWORD }}" == "X" -o \
+               "${{ github.repository_owner }}" != "confidential-containers" ];
           then
               echo "skipping buildah push"
               exit 0

--- a/.github/workflows/build-trustee-image.yml
+++ b/.github/workflows/build-trustee-image.yml
@@ -39,6 +39,14 @@ jobs:
 
       - name: Push container image
         run: |
+          # skip this step if username or password are not defined
+          if [ "X${{ secrets.REGISTRY_USERNAME }}" == "X" \
+               "X${{ secrets.REGISTRY_PASSWORD }}" == "X" ];
+          then
+              echo "skipping buildah push"
+              exit 0
+          fi
+
           # login to quay.io
           echo "${{ secrets.REGISTRY_PASSWORD }}" | buildah login --username "${{ secrets.REGISTRY_USERNAME }}" --password-stdin quay.io
           # push the image

--- a/.github/workflows/build-trustee-image.yml
+++ b/.github/workflows/build-trustee-image.yml
@@ -1,0 +1,48 @@
+name: Build Trustee Container Image
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'configs/trustee/containers/trustee.container'
+  workflow_dispatch: # Allows manual triggering of the workflow
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    container:              # All steps below will run inside this container
+      image: fedora:latest  # Using the latest Fedora image
+      options: --privileged # Required for Buildah to build images without rootless setup
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install Buildah and dependencies in Fedora container
+        run: |
+          dnf update -y
+          dnf install -y buildah git
+          dnf clean all
+
+      - name: Set image name and tag
+        run: |
+          # Fix IMAGE_TAG if other branches are added at the top
+          IMAGE_TAG="latest"
+          IMAGE_NAME="quay.io/confidential-clusters/trustee:${IMAGE_TAG}"
+          # "pass" IMAGE_NAME to the following steps
+          echo "IMAGE_NAME=$IMAGE_NAME" >> $GITHUB_ENV
+          echo "Image name is $IMAGE_NAME"
+
+      - name: Build container image
+        run: |
+          buildah build -t "${{ env.IMAGE_NAME }}" -f configs/trustee/containers/trustee.container .
+
+      - name: Push container image
+        run: |
+          # login to quay.io
+          echo "${{ secrets.REGISTRY_PASSWORD }}" | buildah login --username "${{ secrets.REGISTRY_USERNAME }}" --password-stdin quay.io
+          # push the image
+          buildah push "${{ env.IMAGE_NAME }}"
+          # logout of quay.io
+          buildah logout quay.io
+


### PR DESCRIPTION
Build configs/trustee/containers/trustee* (trustee and trustee-attester) containers.
Push them to quay/confidential-containers (with 'latest' tag).

Quay credentials are saved as github variables.

Only push on the origin (this) repository, not on forks and if the credentials are defined.

Using a Fedora container and buildah. I'm not sure if that's better than simply using the Ubuntu container (and docker).